### PR TITLE
Bug 1228206 - [TV] Add a README file to note where the remote site source code is.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# How to update
+
+  - The repo of this online tutorial content is at https://github.com/mozilla-b2g/casting-tutorial.
+    Please send pull request to this specific repo.
+
+  - Accroding to the bug 1215006: https://bugzilla.mozilla.org/show_bug.cgi?id=1215006,
+    we serve the turotial content at https://casttv.services.mozilla.com/.
+    Please file a bug to jthomas@mozilla.com to update the website.
+
+# The TV tutorial app
+
+  - This tutorial will be loadded by one tutorial app on the TV.
+    The repo of the TV tutorial app is at https://github.com/mozilla-b2g/gaia/tree/master/tv_apps/fling-tutorial


### PR DESCRIPTION
This patch:
- Add one README file to write down the important notices of
  1. How to update
  2. Where to find the TV app loading this online tutorial
