### PR TITLE
Bug 1241366 - [FTE][fling-tutorial][TV][2.5] Need to go back to previous slide by back key

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -19,6 +19,12 @@
     }.bind(tutorial)
   });
 
+  var keyNavAdapter = new KeyNavigationAdapter();
+  keyNavAdapter.init();
+  keyNavAdapter.on('esc-keyup', function () {
+    tutorial.goPrev();
+  });
+
   exports.tutorial = tutorial;
 
 })(window);


### PR DESCRIPTION
This patch:
- Enable to go back to previous tutorial slide by pressing back key
