### PR TITLE
Bug 1244063 - [TV][2.5][FTE] Send to TV's buttons overlap but the layer will incorrect for a while

### DIFF
--- a/style/smart-button.css
+++ b/style/smart-button.css
@@ -38,6 +38,7 @@
 }
 
 .smart-button.focused {
+  z-index: 1;
   outline: 0;
   background-color: #ffffff;
   transform: scale(1.2);


### PR DESCRIPTION
This patch adds z-index  to make sure focused button is top-most during scaling transition.
