### PR TITLE
Bug 1244634 - [TV][2.5][FTE] We need to use short URL for Send tab to TV add-on

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
           <span>
             <span data-l10n-id="download-and-install-addon"></span>
             <br/>
-            <a href="https://addons.mozilla.org/en-US/android/addon/send-tab-to-tv/">https://addons.mozilla.org/en-US/android/addon/send-tab-to-tv/</a>
+            <a href="http://mzl.la/1SrJl5I">http://mzl.la/1SrJl5I</a>
           </span>
         </div>
         <p class="slide-description bottom txt-mid">

--- a/style/index.css
+++ b/style/index.css
@@ -28,6 +28,10 @@ body.finish {
   opacity: 0;
 }
 
+a {
+  color: #fff;
+}
+
 .txt-mid {
   font-size: 3.8rem;
 }


### PR DESCRIPTION
This patch:
- Change the add-on url to the short url
- Change the link color to white by the way
