### PR TITLE
Bug 1286501 - Fling tutorial online content should support ja language

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <img id="slide-1-phoneImg" src="style/images/phone.png">
       </div>
       <div class="slide-section bottom">
-        <button id="slide-1-nextButton" data-behavior="next" class="slide-button primary smart-button" type="rounded-corner-text" data-l10n-id="next"></button>
+        <button id="slide-1-nextButton" data-behavior="next" class="slide-button primary smart-button" type="rounded-corner-text" data-l10n-id="Next"></button>
       </div>
     </div>
 

--- a/locales/casting-tutorial.ja.properties
+++ b/locales/casting-tutorial.ja.properties
@@ -1,0 +1,14 @@
+Next=次へ
+step-1-of-2=ステップ 1/2
+download-firefox-for-android=テレビと連携するためにFirefox for Android<sup>TM</sup>をダウンロードしてください。
+using-same-wifi=お使いのAndroid<sup>TM</sup>機器がテレビと同じネットワークに存在することをご確認ください。
+step-2-of-2=ステップ 2/2
+send-video-to-your-tv=映像をテレビで表示する
+while-playing-video-tap-on-the-send-to-icon=Android<sup>TM</sup>上のFirefoxで映像を視聴されているときに、アドレス入力バーか映像部分に現れる
+appears-on-the-addr-bar-or-on-the-video-player-to-send-video=をタッチしてください。
+learn-send-tab=Android<sup>TM</sup>上のウェブページをテレビで表示する方法
+done=終了
+send-tabs-to-your-tv=タブをテレビで表示する
+download-install-addon=アドオンをAndroid<sup>TM</sup>のFirefoxにインストールしてください。
+while-using-firefox-tap-on-send-to-icon=Android<sup>TM</sup>上のFirefoxご利用時にアドレスバーに現れる
+appears-on-the-addr-bar-to-send-tabs=をタッチするとテレビで同じページを表示できます。


### PR DESCRIPTION
This patch:
- Add casting-tutorial.ja.properties for Japanese
- Fix the data-l10n-id of Next btw
